### PR TITLE
Enable Cgroups Memory

### DIFF
--- a/00-Intro.md
+++ b/00-Intro.md
@@ -164,3 +164,34 @@ Create the directories, positioned in $HOME directory.
 ```shell
 mkdir pki certs config bin plugins
 ```
+
+### Enable Cgroups Memory
+On each worker node append `cgroup_enable=memory cgroup_memory=1` to */boot/cmdline.txt*. This needs to be run as root.
+```
+sudo su
+echo -n ' cgroup_enable=memory cgroup_memory=1' | tee -a /boot/cmdline.txt
+```
+
+Then restart the node:
+```
+sudo shutdown -r 0
+```
+
+Cgroups memory needs to be turned on, or in step 6 [Test Worker Nodes](https://github.com/abelperezok/kubernetes-raspberry-pi-cluster-hat/blob/master/06-Worker-Nodes.md#test-worker-nodes) your node status may all come up as `NotReady`.
+
+After running step 6 on master:
+
+```
+kubectl get nodes --kubeconfig config/admin.kubeconfig
+```
+
+the statuses were all `NotReady`.  Running
+
+```
+journalctl -fu kubelet
+```
+On *p1*, showed an error:
+
+> Failed to start ContainerManager system validation failed - Following Cgroup subsystem not mounted: [memory]  
+
+Turns out that the memory cgroup is disabled by default since it adds some [additional memory overhead](https://github.com/raspberrypi/linux/issues/1950).

--- a/11-References.md
+++ b/11-References.md
@@ -13,3 +13,7 @@
 * https://github.com/kubernetes/kubernetes/issues/26093 
 
 * https://www.raspberrypi.org/forums/viewtopic.php?f=66&t=219644&p=1770842
+
+* https://downey.io/blog/exploring-cgroups-raspberry-pi/
+
+* https://github.com/kubernetes-sigs/kubespray/issues/1227


### PR DESCRIPTION
After completing step 6 [Test Worker Nodes](https://github.com/abelperezok/kubernetes-raspberry-pi-cluster-hat/blob/master/06-Worker-Nodes.md#test-worker-nodes) and running `kubectl get nodes --kubeconfig config/admin.kubeconfig` all node statuses were NotReady. With an error

> Failed to start ContainerManager system validation failed - Following Cgroup subsystem not mounted: [memory]

Turning cgroup memory on for each node, fixed this and all nodes came up Ready.

This PR adds enabling cgroups memory to the Intro page.